### PR TITLE
Change shebang line to be more universal (as per PEP 394)

### DIFF
--- a/wlcppgen.py
+++ b/wlcppgen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Copyright (c) 2013-2014, Dennis Hamester <dennis.hamester@gmail.com>
 #


### PR DESCRIPTION
[PEP 394](https://www.python.org/dev/peps/pep-0394/) states that distributions _should_ bind the `python` command to `python2`, but this is not always the case (see Arch Linux for example), and this script assumes it points to `python3`.

Moreover, the Python executable very well might be located somewhere else than `/usr/bin/python`, replacing it with an `/usr/bin/env` call ensures Python is run regardless of where it is in the `PATH`.
